### PR TITLE
api: dockerize web and db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.6.0-onbuild
+ADD . /app
+WORKDIR /app
+RUN pip install -r requirements.txt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,3 +9,4 @@ web:
     - db
 db:
   image: mongo:3.4.2
+  env_file: .env

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+web:
+  build: .
+  command: python -u app.py
+  ports:
+    - "5000:5000"
+  volumes:
+    - .:/app
+  links:
+    - db
+db:
+  image: mongo:3.4.2

--- a/env.template
+++ b/env.template
@@ -1,4 +1,4 @@
-HOST_URL=127.0.0.1
+HOST_URL=0.0.0.0
 PORT=5000
 
 DATABASE_URL=mongodb://localhost:27017/

--- a/settings.py
+++ b/settings.py
@@ -11,7 +11,7 @@ dotenv_file = os.path.join(BASE_DIR, ".env")
 if os.path.isfile(dotenv_file):
     dotenv.load_dotenv(dotenv_file)
 
-HOST = os.environ.get('HOST', '127.0.0.1')
+HOST = os.environ.get('HOST', '0.0.0.0')
 PORT = int(os.environ.get('PORT', 5000))
 
 DATABASE_URL = os.environ.get('DATABASE_URL')


### PR DESCRIPTION
This PR puts the web and database in docker containers. You can read more about docker [here](https://www.docker.com/), but it's not super important to learn docker right now, especially if you're developing on Cloud9 which doesn't support docker (in fact, Cloud9 runs in Docker!).

When we actually deploy this to the real world, we'll ship everything in docker containers. This and https://github.com/j2kun/lonely-hearts/issues/46 anticipate this. @DanielNghiem if you aren't running on your own machine, then you can safely ignore everything below, which I'm just writing down for my own historical record in case I forget.

Requirements:

 - `docker`
 - `docker-machine`
 - `docker-compose`

To run, from the base directory of the project, assuming you have created a docker machine called `default` which is currently running (`docker-machine start default`)

```
eval $(docker-machine env default)
docker-compose build
docker-compose up -d
```

Then you can see the containers with `docker ps`. Note that to connect to the app inside the docker container, you must have the following in your `.env`:

```
HOST_URL=0.0.0.0
PORT=5000
```

The value `0.0.0.0` makes the flask app visible outside the container, whereas `127.0.0.1` would only make it visible from inside the virtual machine (security reasons)

along with the IP for the output of `docker-machine ls`

```
$ docker-machine ls
NAME      ACTIVE   DRIVER       STATE     URL                         SWARM   DOCKER    ERRORS
default   *        virtualbox   Running   tcp://192.168.99.100:2376           v1.11.1   
```

The url `http://192.168.99.100:5000` is where you'd visit in your browser (until I set up an nginx forwarding container), and the host `192.168.99.100` is required in your `.env` to tell the web app where to look for the database:

```
DATABASE_URL=mongodb://192.168.99.100:27017/
DATABASE_NAME=hearts
```