### PR TITLE
frontend: get socket connections working with rooms

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,4 +73,4 @@ def room(room_id):
 
 
 if __name__ == '__main__':
-    socketio.run(app)
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/static/room.js
+++ b/static/room.js
@@ -93,10 +93,6 @@ function render(state) {
 
 function setup() {
     $("body").removeClass("preload");
-    // var socket = io.connect('http://127.0.0.1:5000/chat');
-    //socket.on('chat message', function(msg){
-    //    $('#messages').append($('<li>').text(msg));
-    //});
     render(state);
 }
 

--- a/static/socket_api.js
+++ b/static/socket_api.js
@@ -14,18 +14,19 @@ function RoomSocket(api_url) {
     this.api_url = api_url;
     this.socket = io(this.api_url);
     this.socket.on(CHAT, function(data) {
-        console.log(data);
+        console.log('User chatted: ' + data);
     });
 
     this.join_room = function(room_id) {
         this.room_id = room_id;
         this.socket.emit('join', {
-            room: this.room_id, 
+            room: this.room_id,
             username: 'Bill' + makeid(),
         });
     };
 
     this.chat = function(message) {
+        console.log('Submitting chat: ' + message);
         this.socket.emit(CHAT, message);
     }
 }

--- a/static/socket_api.js
+++ b/static/socket_api.js
@@ -1,0 +1,15 @@
+var CHAT = 'chat';
+
+function api(api_url) {
+    this.api_url = api_url;
+    this.socket = io(this.api_url);
+
+    this.join_room = function(room_id) {
+        this.room_id = room_id;
+        this.socket.emit('join', {room: this.room_id, username: 'Bill'});
+    };
+
+    this.chat = function(message) {
+        this.socket.emit('chat', message);
+    }
+}

--- a/static/socket_api.js
+++ b/static/socket_api.js
@@ -1,15 +1,31 @@
 var CHAT = 'chat';
 
-function api(api_url) {
+function makeid() {
+    var text = "";
+    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    for( var i=0; i < 5; i++ )
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+    return text;
+}
+
+function RoomSocket(api_url) {
     this.api_url = api_url;
     this.socket = io(this.api_url);
+    this.socket.on(CHAT, function(data) {
+        console.log(data);
+    });
 
     this.join_room = function(room_id) {
         this.room_id = room_id;
-        this.socket.emit('join', {room: this.room_id, username: 'Bill'});
+        this.socket.emit('join', {
+            room: this.room_id, 
+            username: 'Bill' + makeid(),
+        });
     };
 
     this.chat = function(message) {
-        this.socket.emit('chat', message);
+        this.socket.emit(CHAT, message);
     }
 }

--- a/templates/room.html
+++ b/templates/room.html
@@ -43,7 +43,9 @@
 <script src="{{url_for('static', filename='socket_api.js')}}"></script>
 
 <script>
-api.join_room( {{ room_id }} );
+var client = new RoomSocket("{{ api_url }}");
+client.join_room("{{ room_id }}");
+client.chat("I'm saaillling aawaayy");
 </script>
 
 <script src="{{url_for('static', filename='room.js')}}"></script>

--- a/templates/room.html
+++ b/templates/room.html
@@ -40,6 +40,12 @@
 
 <script src="{{url_for('static', filename='socket.io.min.js')}}"></script>
 <script src="{{url_for('static', filename='jquery.js')}}"></script>
+<script src="{{url_for('static', filename='socket_api.js')}}"></script>
+
+<script>
+api.join_room( {{ room_id }} );
+</script>
+
 <script src="{{url_for('static', filename='room.js')}}"></script>
 
 </body>


### PR DESCRIPTION
Note this PR has a few silly bits that will be removed in subsequent PRs

----------------------

This PR gets socket connections working with "rooms." 

The api for connecting to a socket looks like:

```
<script>
var client = new RoomSocket("{{ api_url }}");   // this value is actually empty for now
client.join_room("{{ room_id }}");
client.chat("I'm saaillling aawaayy");
</script>
```

Steps to observe correct behavior:

1. Start the web server (and database)
2. Open one browser window to `http://0.0.0.0:5000`, and click "new room"
3. Observe the server logs:
```
join ('Billa9sA2', '58d48b9065294312aeb738ec')
(70864) accepted ('127.0.0.1', 57218)
received message: I'm saaillling aawaayy
```
4. Note in `static/socket_api.js` the behavior on receiving a message is to log it to the console
5. Right click on the browser page for the room, and click "Inspect", and click on the Console tab to see the console log for `I'm saaillling aawaayy` (this is how you know the client received the emitted message from the server)
6. Copy the url and open it in a second browser tab, repeat 5.
7. Go back to the first browser tab's console, and see a second `I'm saaillling aawaayy` message, which was sent via the websockets.

All of the chatting is also restricted to this room, so anyone who joins a different room will get their own channel to talk on.