### PR TITLE
conftest: fix app context so one can use mongo in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,4 +28,4 @@ def socket_client(request):
 def db(api_client, request):
     with app.app_context():
         mongo.db.command('dropDatabase')
-        return mongo.db
+        yield mongo.db

--- a/hearts/api/tests/test_socket_events.py
+++ b/hearts/api/tests/test_socket_events.py
@@ -1,7 +1,13 @@
+from hearts.api.rooms import create_room
 
 
 def test_db(db):
     assert db.rooms.find({}).count() == 0
+
+
+def test_create_room(db):
+    test_room = create_room()
+    assert test_room['users'] == []
 
 
 def test_on_join_valid_room(api_client, socket_client, db):


### PR DESCRIPTION
This PR makes a very small change (`return` -> `yield`) that fixes the application context problem.

So Flask app context is really annoying and needlessly complicated. I'm not going to bother you with those details because it probably won't come up again and I still don't fully understand it. The thing is that, basically, the pymongo extension connects the mongodb client to the flask app, and flask complains when it's not inside a `with app.app_context()`, because if there are multiple flask apps at the same time it doesn't know which app it's supposed to be. Whatever. Point is that we need to ensure any time we run a db command (and it's not inside a view or socket handler), we have to manually make sure the mongodb client is inside the scope of a  `with app.app_context()`.

That was not happening before this PR because we were `return`ing `mongo.db` in line 31 of conftest.py, and when you return from a function it exits the with statement and the with statement calls `close` on the app context, effectively disconnecting it from the mongo client.

However, it turns out `py.test` allows you to define fixtures as python generators, which means if you `yield` from a fixture you get the same behavior (the `yield`ed value is returned to the caller of the fixture), but this preserves the function call's internal state, so the with statement is not exited until after the test finishes. (It turns out, at the end of the test py.test continues the "iteration", re-entering the fixture function which allows you to do some manual cleanup if you want, but we don't need to do that).

I also cherry-picked the commit from your branch that tests `create_room`, to ensure it was working as expected.