### PR TITLE
api: add docstrings to api_views and rooms

### DIFF
--- a/hearts/api/rest_views.py
+++ b/hearts/api/rest_views.py
@@ -22,14 +22,23 @@ def index():
 
 @app.route('/rooms/', methods=['POST'])
 def rooms():
+    '''
+    POST /rooms/  - create a new room
+
+    Returns:
+        {
+          'url': str
+        }
+
+    Visit the given url to join the created room.
+    '''
     if request.method == 'POST':
         try:
             room = create_room()
-            room_id = str(room['_id'])
+            room_id = room['_id']
             logger.info('rooms - created new room id={}'.format(room_id))
             return jsonify({
                 'url': '/rooms/%s/' % room_id,
-                'id': room_id,
             })
         except RoomCreateFailed:
             logger.critical('rooms - failed to create a new room')
@@ -37,6 +46,9 @@ def rooms():
 
 @app.route('/rooms/<room_id>/', methods=['GET'])
 def room(room_id):
+    '''
+    GET /rooms/<room_id>/  - join a given room
+    '''
     if request.method == 'GET':
         try:
             get_room(room_id)

--- a/hearts/api/rooms.py
+++ b/hearts/api/rooms.py
@@ -1,17 +1,46 @@
+'''
+Helper functions for interacting with rooms.
+
+A room object has the following fields
+
+    {
+      '_id': ObjectId,
+      'users': iterable of strings,
+    }
+'''
+
 from bson.objectid import ObjectId
 
 from hearts import mongo
 
 
 class RoomDoesNotExist(Exception):
+    '''
+    Exception thrown when trying to get a room that does not exist
+    '''
     pass
 
 
 class RoomCreateFailed(Exception):
+    '''
+    Exception thrown when room creation fails
+    '''
     pass
 
 
 def get_room(room_id):
+    '''
+    Get a room from the database
+
+    Input:
+        room_id: string or ObjectId
+
+    Output:
+        {
+          '_id': ObjectId,
+          'users': iterable of strings,
+        }
+    '''
     try:
         if not isinstance(room_id, ObjectId):
             room_id = ObjectId(room_id)
@@ -26,6 +55,18 @@ def get_room(room_id):
 
 
 def create_room(users=tuple()):
+    '''
+    Create a new room with the given users
+
+    Input:
+        users: iterable of strings
+
+    Output:
+        {
+          '_id': ObjectId,
+          'users': iterable of strings,
+        }
+    '''
     room_id = mongo.db.rooms.insert({'users': users})
     if room_id:
         return get_room(room_id)

--- a/hearts/api/tests/test_rooms_api.py
+++ b/hearts/api/tests/test_rooms_api.py
@@ -1,16 +1,11 @@
-from bson.objectid import ObjectId
-
 from tests.utils import json_data
 
 
 def test_create_room(api_client, db):
     response = json_data(api_client.post('/rooms/'))
     assert response['url']
-    room_id = ObjectId(response['id'])
-    cursor = db.rooms.find({"_id": room_id})
-    assert cursor.count() == 1
-    assert cursor[0]['users'] == []
-
+    room_id = response['url'].split('/')[2]
+    assert room_id
     response = api_client.get(response['url'])
     assert response.status_code == 200
     assert response.content_type.startswith('text/html')
@@ -18,7 +13,7 @@ def test_create_room(api_client, db):
 
 def test_join_room(api_client, socket_client, db):
     response = json_data(api_client.post('/rooms/'))
-    room_id = response['id']
+    room_id = response['url'].split('/')[2]
     socket_client.emit('join', {'room': room_id, 'username': 'wat'})
 
     received = socket_client.get_received()


### PR DESCRIPTION
I looked at https://github.com/j2kun/lonely-hearts/issues/75 and realized that the room_id string doesn't apply anymore. So to keep a single source of truth, I added docstrings to the room module in this PR.

Any time we want to interact with a room, we should put that functionality in `rooms.py`. Example: 

```
def add_user(room, username):
   if len(room['users']) >= 4:
      raise RoomIsFull()
   else:
      # mongodb update query
```

Then in the socket view for joining a room, we can do like

```
try:
    room = rooms.get_room(data['room_id'])
    rooms.add_user(room, data['username'])
except rooms.RoomIsFull:
    emit some error
except rooms.RoomDoesNotExist:
    emit some error
```