### PR TITLE
Refactor all serialize() functions in hearts.py to return the correct variable types

### DIFF
--- a/hearts/game/tests/test_game.py
+++ b/hearts/game/tests/test_game.py
@@ -122,7 +122,7 @@ def test_deserialize_game_check_player_data():
     test_game.players = test_players  # Seat players in the order: Lauren, Erin, Jeremy, Daniel
 
     assert test_game.players == [Player('Lauren'), Player('Erin'), Player('Jeremy'), Player('Daniel')]
-    assert test_game.serialize()['players'] == [Player('Lauren'), Player('Erin'), Player('Jeremy'), Player('Daniel')]
+    assert test_game.serialize()['players'] == ['Lauren', 'Erin', 'Jeremy', 'Daniel']
     assert Game.deserialize(test_game.serialize()).players == [Player('Lauren'),
                                                                Player('Erin'),
                                                                Player('Jeremy'),

--- a/hearts/game/tests/test_round.py
+++ b/hearts/game/tests/test_round.py
@@ -612,5 +612,4 @@ def test_deserialize_round():
     test_round.hands = test_hands
     test_round.turn_counter = 3
     test_round.hearts_broken = True
-
     assert test_round == Round.deserialize(test_round.serialize())


### PR DESCRIPTION
This PR ensures that `Game.serialize()` and `Round.serialize()` functions return JSON serializable dictionaries by replacing all instances of `Player` objects with `Player.username` strings.