### PR TITLE
API: Refactor create_room() and limit 4 users per room

### DIFF
--- a/hearts/api/rest_views.py
+++ b/hearts/api/rest_views.py
@@ -35,8 +35,7 @@ def rooms():
     '''
     if request.method == 'POST':
         try:
-            room = create_room()
-            room_id = room['_id']
+            room, room_id = create_room()
             logger.info('rooms - created new room id={}'.format(room_id))
             return jsonify({
                 'url': '/rooms/%s/' % room_id,

--- a/hearts/api/rooms.py
+++ b/hearts/api/rooms.py
@@ -5,8 +5,11 @@ A room object has the following fields
 
     {
       '_id': ObjectId,
-      'users': iterable of strings,
+      'users': [{'username': str, 'socket_id': str}]
+      'game_id': ObjectId of most recent game created
     }
+
+The 'users' field is indexed by the order in which the users joined.
 '''
 
 from bson.objectid import ObjectId
@@ -36,10 +39,6 @@ def get_room(room_id):
         room_id: string or ObjectId
 
     Output:
-        {
-          '_id': ObjectId,
-          'users': iterable of strings,
-        }
     '''
     try:
         if not isinstance(room_id, ObjectId):
@@ -62,10 +61,6 @@ def create_room(users=tuple()):
         users: iterable of strings
 
     Output:
-        {
-          '_id': ObjectId,
-          'users': iterable of strings,
-        }
     '''
     room_id = mongo.db.rooms.insert({'users': users})
     if room_id:

--- a/hearts/api/rooms.py
+++ b/hearts/api/rooms.py
@@ -39,6 +39,7 @@ def get_room(room_id):
         room_id: string or ObjectId
 
     Output:
+        A room object.
     '''
     try:
         if not isinstance(room_id, ObjectId):
@@ -58,12 +59,13 @@ def create_room(users=tuple()):
     Create a new room with the given users
 
     Input:
-        users: iterable of strings
+        An iterable of dicts {'username': str, 'socket_id': str}
 
     Output:
+        A tuple (Room, str)
     '''
     room_id = mongo.db.rooms.insert({'users': users})
     if room_id:
-        return get_room(room_id)
+        return get_room(room_id), str(room_id)
     else:
         raise RoomCreateFailed()

--- a/hearts/api/strings.py
+++ b/hearts/api/strings.py
@@ -1,4 +1,4 @@
-
+ROOM_IS_FULL = 'This room is full!'
 
 INVALID_PLAY = 'You cannot play {} because {reason}'
 INVALID_PASS = 'You cannot pass {} because {reason}'

--- a/hearts/api/tests/test_socket_events.py
+++ b/hearts/api/tests/test_socket_events.py
@@ -1,5 +1,4 @@
 import pytest
-
 from bson import ObjectId
 
 from hearts.api.rooms import create_room
@@ -41,6 +40,17 @@ def test_on_join_valid_room(api_client, socket_client, db):
     for data in test_room['users']:
         assert 'username' in data
         assert 'socket_id' in data
+
+
+def test_on_join_room_is_full(db, socket_client):
+    room, room_id = create_room(users)
+    socket_client.emit('join', {'room': room_id, 'username': 'user_5'})
+    received = socket_client.get_received()
+    messages = [event for event in received if event['name'] == 'message']
+    assert len(messages) == 1
+    assert messages[0]['args'] == 'This room is full!'
+    for user in get_room(room_id)['users']:
+        assert user['username'] != 'user_5'
 
 
 def test_create_game_write_to_database(db):


### PR DESCRIPTION
This PR does the following:
1. In `api/rooms.py`: Changes the return value of `create_room()` to return a room_id string in addition to a Room object.
2. In `api/socket_events.py`: No longer allows more than 4 players to join a room.  