### PR TITLE
api/games:  get_game() and save_game()

### DIFF
--- a/hearts/api/games.py
+++ b/hearts/api/games.py
@@ -100,3 +100,24 @@ def create_game(room_id, max_points=100, deserialize=True):
             return game, game_id
     else:
         raise NotEnoughPlayers()
+
+
+def save_game(game, game_id):
+    '''
+    Serializes a game and updates it in the database.
+
+    Input: 
+        game: A deserialized Game object
+        game_id: ObjectId or string
+    '''
+    try:
+        if not isinstance(game_id, ObjectId):
+            game_id = ObjectId(game_id)
+    except TypeError:
+        raise TypeError("game_id must be a string or ObjectId, was {}".format(type(game_id).__name__))
+
+    mongo.db.games.update_one(
+        {'_id': game_id},
+        {'$set': {'data': game.serialize()}}
+    )
+

--- a/hearts/api/games.py
+++ b/hearts/api/games.py
@@ -38,16 +38,14 @@ class NotEnoughPlayers(Exception):
     pass
 
 
-def get_game(game_id):
+def get_game(game_id, deserialize=True):
     '''
     Get a game from the database.
     Input:
         game_id: string or ObjectId
     Output:
-        {
-          '_id': ObjectId,
-          'data': serialized Game object
-        }
+        A deserialized Game object if deserilize=True.
+        Otherwise, a Game object from the database.
     '''
     try:
         if not isinstance(game_id, ObjectId):
@@ -59,7 +57,10 @@ def get_game(game_id):
     if not result:
         raise GameDoesNotExist()
 
-    return result
+    if not deserialize:
+        return result
+    else:
+        return Game.deserialize(result['data'])
 
 
 def create_game(room_id, max_points=100, deserialize=True):
@@ -95,7 +96,7 @@ def create_game(room_id, max_points=100, deserialize=True):
         if deserialize:
             return new_game, game_id
         else:
-            game = mongo.db.games.find_one({'_id': game_id})
+            game = get_game(game_id, deserialize=False)
             return game, game_id
     else:
         raise NotEnoughPlayers()

--- a/hearts/api/games.py
+++ b/hearts/api/games.py
@@ -106,7 +106,7 @@ def save_game(game, game_id):
     '''
     Serializes a game and updates it in the database.
 
-    Input: 
+    Input:
         game: A deserialized Game object
         game_id: ObjectId or string
     '''
@@ -120,4 +120,3 @@ def save_game(game, game_id):
         {'_id': game_id},
         {'$set': {'data': game.serialize()}}
     )
-

--- a/hearts/api/tests/test_socket_events.py
+++ b/hearts/api/tests/test_socket_events.py
@@ -61,7 +61,9 @@ def test_get_game(db):
     test_room, test_room_id = create_room(users)
     game, game_id = create_game(test_room_id, deserialize=True)
     assert isinstance(game, Game)
-    serialized, game_id = create_game(test_room_id, deserialize=False)
+    assert game == get_game(game_id, deserialize=True)
+
+    serialized = get_game(game_id, deserialize=False)
     assert 'users' in serialized
     assert 'data' in serialized
 

--- a/hearts/api/tests/test_socket_events.py
+++ b/hearts/api/tests/test_socket_events.py
@@ -1,6 +1,8 @@
 import pytest
+
 from bson import ObjectId
 
+from hearts.game.hearts import Game
 from hearts.api.rooms import create_room
 from hearts.api.rooms import get_room
 from hearts.api.games import create_game
@@ -53,7 +55,16 @@ def test_on_join_room_is_full(db, socket_client):
         assert user['username'] != 'user_5'
 
 
-def test_create_game_write_to_database(db):
+def test_get_game(db):
+    test_room, test_room_id = create_room(users)
+    game, game_id = create_game(test_room_id, deserialize=True)
+    assert isinstance(game, Game)
+    serialized, game_id = create_game(test_room_id, deserialize=False)
+    assert 'users' in serialized
+    assert 'data' in serialized
+
+
+def test_create_game_for_serialized_data(db):
     test_room, test_room_id = create_room(users)
     game, game_id = create_game(test_room_id, deserialize=False)
 

--- a/hearts/api/tests/test_socket_events.py
+++ b/hearts/api/tests/test_socket_events.py
@@ -6,6 +6,8 @@ from hearts.game.hearts import Game
 from hearts.api.rooms import create_room
 from hearts.api.rooms import get_room
 from hearts.api.games import create_game
+from hearts.api.games import get_game
+from hearts.api.games import save_game
 from hearts.api.games import NotEnoughPlayers
 
 
@@ -62,6 +64,19 @@ def test_get_game(db):
     serialized, game_id = create_game(test_room_id, deserialize=False)
     assert 'users' in serialized
     assert 'data' in serialized
+
+
+def test_save_game(db):
+    room, room_id = create_room(users)
+    game, game_id = create_game(room_id)
+    save_game(game, game_id)
+    assert game.round_number == 0
+    assert game == get_game(game_id)
+
+    game.round_number += 1
+    assert game.round_number == 1
+    save_game(game, game_id)
+    assert game == get_game(game_id)
 
 
 def test_create_game_for_serialized_data(db):


### PR DESCRIPTION
This PR adds the following in hearts/api/games.py:

1. The `get_game()` function can now return either a serialized database object or a deserialized Game object using the `deserialize` flag.

2. A `save_game()` function was added.  It stores a serialized game to the database.

3. Tests for both functions.